### PR TITLE
Ayudar con la vista previa de la aplicación

### DIFF
--- a/app/src/main/java/com/example/proyecto_movil/feature/album/ui/AlbumReviewScreen.kt
+++ b/app/src/main/java/com/example/proyecto_movil/feature/album/ui/AlbumReviewScreen.kt
@@ -24,6 +24,7 @@ import com.example.proyecto_movil.ui_components.SectionTitle
 import com.example.proyecto_movil.ui_components.ScreenBackground
 import com.example.proyecto_movil.ui_components.SettingsIcon
 import com.example.proyecto_movil.utils.recursos.AlbumUi
+import com.example.proyecto_movil.utils.recursos.ArtistUI
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -95,12 +96,25 @@ fun albumReviewScreen(
     }
 }
 
-@Preview(showBackground = true,)
+@Preview(showBackground = true, name = "AlbumReviewScreen Preview")
 @Composable
 fun albumReviewScreenPreview() {
+    val sampleAlbum = AlbumUi(
+        id = 1,
+        coverRes = R.drawable.tyler_dttg,
+        title = "DON'T TAP THE GLASS",
+        year = "2024",
+        artist = ArtistUI(
+            id = 1,
+            name = "Tyler, The Creator",
+            genre = "Hip Hop",
+            displayName = "Tyler, The Creator"
+        )
+    )
+
     albumReviewScreen(
-        album = TODO(),
-        modifier = TODO(),
-        onArtistClick = TODO()
+        album = sampleAlbum,
+        modifier = Modifier,
+        onArtistClick = {}
     )
 }


### PR DESCRIPTION
Replace `TODO()` placeholders with sample data in `AlbumReviewScreen.kt` to fix Compose preview crashes.

---
<a href="https://cursor.com/background-agent?bcId=bc-e1ea04be-e904-415a-aa0f-f257cda14a51">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e1ea04be-e904-415a-aa0f-f257cda14a51">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

