### PR TITLE
Create register viewmodel and fix navigation

### DIFF
--- a/app/src/main/java/com/example/proyecto_movil/feature/auth/ui/RegisterViewModel.kt
+++ b/app/src/main/java/com/example/proyecto_movil/feature/auth/ui/RegisterViewModel.kt
@@ -1,0 +1,41 @@
+package com.example.proyecto_movil.feature.auth.ui
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+data class RegisterUiState(
+    val isLoading: Boolean = false,
+    val isRegistered: Boolean = false,
+    val errorMessage: String? = null
+)
+
+class RegisterViewModel : ViewModel() {
+
+    private val _state = MutableStateFlow(RegisterUiState())
+    val state: StateFlow<RegisterUiState> = _state.asStateFlow()
+
+    fun registerUser(username: String, email: String, password: String) {
+        if (username.isBlank() || email.isBlank() || password.isBlank()) {
+            _state.update { it.copy(errorMessage = "Todos los campos son obligatorios") }
+            return
+        }
+
+        viewModelScope.launch {
+            _state.update { it.copy(isLoading = true, errorMessage = null) }
+            // Simulación de petición de registro. Sustituir por repositorio real.
+            delay(500)
+            _state.update { it.copy(isLoading = false, isRegistered = true) }
+        }
+    }
+
+    fun clearError() {
+        _state.update { it.copy(errorMessage = null) }
+    }
+}
+

--- a/app/src/main/java/com/example/proyecto_movil/navigation/NavGraph.kt
+++ b/app/src/main/java/com/example/proyecto_movil/navigation/NavGraph.kt
@@ -52,10 +52,14 @@ fun AppNavHost(
         }
 
         composable(Screen.Register.route) {
-            RegisterScreen2(
-                modifier = Modifier,
+            RegisterRoute(
                 onBack = { navController.navigateUp() },
-                onRegister = { _, _, _ -> navController.navigate(Screen.Home.route) },
+                onRegistered = {
+                    navController.navigate(Screen.Home.route) {
+                        popUpTo(Screen.Welcome.route) { inclusive = true }
+                        launchSingleTop = true
+                    }
+                },
                 onLogin = { navController.navigate(Screen.Login.route) }
             )
         }

--- a/app/src/main/java/com/example/proyecto_movil/screen/RegisterRoute.kt
+++ b/app/src/main/java/com/example/proyecto_movil/screen/RegisterRoute.kt
@@ -1,0 +1,53 @@
+package com.example.proyecto_movil.screen
+
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.example.proyecto_movil.feature.auth.ui.RegisterViewModel
+
+@Composable
+fun RegisterRoute(
+    onBack: () -> Unit,
+    onRegistered: () -> Unit,
+    onLogin: () -> Unit
+) {
+    val vm: RegisterViewModel = viewModel()
+    val uiState = vm.state.collectAsStateWithLifecycle().value
+
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    LaunchedEffect(uiState.errorMessage) {
+        val msg = uiState.errorMessage
+        if (msg != null) {
+            snackbarHostState.showSnackbar(message = msg)
+            vm.clearError()
+        }
+    }
+
+    LaunchedEffect(uiState.isRegistered) {
+        if (uiState.isRegistered) onRegistered()
+    }
+
+    RegisterScreen2(
+        onBack = onBack,
+        onRegister = { username, email, password ->
+            vm.registerUser(username, email, password)
+        },
+        onLogin = onLogin
+    )
+
+    if (uiState.isLoading) {
+        CircularProgressIndicator()
+    }
+
+    SnackbarHost(hostState = snackbarHostState) { data ->
+        Text(text = data.visuals.message)
+    }
+}
+


### PR DESCRIPTION
Introduce `RegisterViewModel` and `RegisterRoute` to manage registration state and integrate it into the navigation graph following a route wrapper pattern.

---
<a href="https://cursor.com/background-agent?bcId=bc-50f4743b-5e61-44dc-8f70-087d879b14c0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-50f4743b-5e61-44dc-8f70-087d879b14c0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

